### PR TITLE
Added support for external Redis connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,25 @@ which is used internally to connect to Redis.
 
 This constructor creates two connections to Redis.
 
+Alternatively, you can pass in an externally created Redis connection using the
+`conn` option. This can be useful when connecting to a Redis cluster, for example.
+
+Example:
+
+```js
+var redis = require('mqemitter-redis')
+var Redis = require('ioredis')
+var mq = redis({
+  conn: new Redis.Cluster([{
+    port: 6379,
+    host: '127.0.0.1'
+  }, {
+    port: 6380,
+    host: '127.0.0.1'
+  }])
+})
+```
+
 Acknowledgements
 ----------------
 

--- a/mqemitter-redis.js
+++ b/mqemitter-redis.js
@@ -16,8 +16,8 @@ function MQEmitterRedis (opts) {
   opts = opts || {}
   this._opts = opts
 
-  this.subConn = new Redis(opts)
-  this.pubConn = new Redis(opts)
+  this.pubConn = opts.conn || new Redis(opts)
+  this.subConn = opts.subConn || this.pubConn.duplicate()
 
   this._topics = {}
 


### PR DESCRIPTION
The main reason for this PR is to support connecting to Redis clusters. Currently, the `MQEmitterRedis` constructor assumes you will be creating a connection to a single Redis server and internally makes a call to `new Redis(opts)`. However, in order to connect to a Redis cluster, you must use the `Redis.Cluster` constructor of `ioredis`. This PR allows you to pass in any Redis instance as the value of a new conn option. This allows you to construct a new `Redis.Cluster` connection outside of the `MQEmitterRedis` constructor and pass it in as an argument.

NOTE: There is currently no unit test for this PR since I wasn't sure of the best approach to testing with a redis cluster. Suggestions?