### PR TITLE
fix issue #22

### DIFF
--- a/mqemitter-redis.js
+++ b/mqemitter-redis.js
@@ -197,63 +197,30 @@ function noop () {}
 
 module.exports = MQEmitterRedis
 
-/*class MQEmitterRedisPrefix extends MQEmitterRedis {
-	#pubSubPrefix;
-	#proxiedCallback;
-	constructor(pubSubPrefix, options) {
-		super(options);
-		this.#pubSubPrefix = pubSubPrefix;
-		this.#proxiedCallback = Symbol('proxiedCallback');
-	}
-
-	on(topic, cb, done) {
-		const t = this.#pubSubPrefix+topic;
-		cb[this.#proxiedCallback] = (packet, cbcb) => {
-			const t = packet.topic.slice(this.#pubSubPrefix.length);
-			const p = { ...packet, topic: t };
-			return cb(p, cbcb);
-		};
-		return super.on(t, cb[this.#proxiedCallback], done);
-	};
-
-	removeListener(topic, func, done) {
-		const t = this.#pubSubPrefix+topic;
-		const f = func[this.#proxiedCallback];
-		return super.removeListener(t, f, done);
-	};
-
-	emit(packet, done) {
-		const t = this.#pubSubPrefix+packet.topic;
-		const p = { ...packet, topic: t };
-		return super.emit(p, done);
-	};
-};*/
-
-function MQEmitterRedisPrefix(pubSubPrefix, options) {
-	assert(this instanceof MQEmitterRedisPrefix);
-	MQEmitterRedis.call(this, options);
-	this._pubSubPrefix = pubSubPrefix;
-	this._sym_proxiedCallback = '_private_symbol_MQEmitterRedisPrefix_proxiedCallback'; //Symbol('proxiedCallback');
+function MQEmitterRedisPrefix (pubSubPrefix, options) {
+  MQEmitterRedis.call(this, options)
+  this._pubSubPrefix = pubSubPrefix
+  this._sym_proxiedCallback = '_private_symbol_MQEmitterRedisPrefix_proxiedCallback' // Symbol('proxiedCallback');
 }
-inherits(MQEmitterRedisPrefix, MQEmitterRedis);
-MQEmitterRedisPrefix.prototype.on = function(topic, cb, done){
-	var t = this._pubSubPrefix+topic;
-	cb[this._sym_proxiedCallback] = (function(packet, cbcb){
-    var t = packet.topic.slice(this._pubSubPrefix.length);
-		var p = { ...packet, topic: t };
-		return cb(p, cbcb);
-	}).bind(this);
-	return MQEmitterRedis.prototype.on.call(this, t, cb[this._sym_proxiedCallback], done);
-};
-MQEmitterRedisPrefix.prototype.removeListener = function(topic, func, done){
-	var t = this._pubSubPrefix+topic;
-	var f = func[this._sym_proxiedCallback];
-	return MQEmitterRedis.prototype.removeListener.call(this, t, f, done);
-};
-MQEmitterRedisPrefix.prototype.emit = function(packet, done){
-	var t = this._pubSubPrefix+packet.topic;
-	var p = { ...packet, topic: t };
-	return MQEmitterRedis.prototype.emit.call(this, p, done);
-};
+inherits(MQEmitterRedisPrefix, MQEmitterRedis)
+MQEmitterRedisPrefix.prototype.on = function (topic, cb, done) {
+  const t = this._pubSubPrefix + topic
+  cb[this._sym_proxiedCallback] = function (packet, cbcb) {
+    const t = packet.topic.slice(this._pubSubPrefix.length)
+    const p = { ...packet, topic: t }
+    return cb(p, cbcb)
+  }.bind(this)
+  return MQEmitterRedis.prototype.on.call(this, t, cb[this._sym_proxiedCallback], done)
+}
+MQEmitterRedisPrefix.prototype.removeListener = function (topic, func, done) {
+  const t = this._pubSubPrefix + topic
+  const f = func[this._sym_proxiedCallback]
+  return MQEmitterRedis.prototype.removeListener.call(this, t, f, done)
+}
+MQEmitterRedisPrefix.prototype.emit = function (packet, done) {
+  const t = this._pubSubPrefix + packet.topic
+  const p = { ...packet, topic: t }
+  return MQEmitterRedis.prototype.emit.call(this, p, done)
+}
 
-module.exports.MQEmitterRedisPrefix = MQEmitterRedisPrefix;
+module.exports.MQEmitterRedisPrefix = MQEmitterRedisPrefix

--- a/mqemitter-redis.js
+++ b/mqemitter-redis.js
@@ -208,7 +208,7 @@ MQEmitterRedisPrefix.prototype.on = function (topic, cb, done) {
   cb[this._sym_proxiedCallback] = function (packet, cbcb) {
     const t = packet.topic.slice(this._pubSubPrefix.length)
     const p = { ...packet, topic: t }
-    return cb(p, cbcb)
+    return cb.call(this, p, cbcb)
   }.bind(this)
   return MQEmitterRedis.prototype.on.call(this, t, cb[this._sym_proxiedCallback], done)
 }

--- a/mqemitter-redis.js
+++ b/mqemitter-redis.js
@@ -197,7 +197,7 @@ function noop () {}
 
 module.exports = MQEmitterRedis
 
-class MQEmitterRedisPrefix extends MQEmitterRedis {
+/*class MQEmitterRedisPrefix extends MQEmitterRedis {
 	#pubSubPrefix;
 	#proxiedCallback;
 	constructor(pubSubPrefix, options) {
@@ -227,6 +227,33 @@ class MQEmitterRedisPrefix extends MQEmitterRedis {
 		const p = { ...packet, topic: t };
 		return super.emit(p, done);
 	};
+};*/
+
+function MQEmitterRedisPrefix(pubSubPrefix, options) {
+	assert(this instanceof MQEmitterRedisPrefix);
+	MQEmitterRedis.call(this, options);
+	this._pubSubPrefix = pubSubPrefix;
+	this._sym_proxiedCallback = '_private_symbol_MQEmitterRedisPrefix_proxiedCallback'; //Symbol('proxiedCallback');
+}
+inherits(MQEmitterRedisPrefix, MQEmitterRedis);
+MQEmitterRedisPrefix.prototype.on = function(topic, cb, done){
+	var t = this._pubSubPrefix+topic;
+	cb[this._sym_proxiedCallback] = (function(packet, cbcb){
+    var t = packet.topic.slice(this._pubSubPrefix.length);
+		var p = { ...packet, topic: t };
+		return cb(p, cbcb);
+	}).bind(this);
+	return MQEmitterRedis.prototype.on.call(this, t, cb[this._sym_proxiedCallback], done);
+};
+MQEmitterRedisPrefix.prototype.removeListener = function(topic, func, done){
+	var t = this._pubSubPrefix+topic;
+	var f = func[this._sym_proxiedCallback];
+	return MQEmitterRedis.prototype.removeListener.call(this, t, f, done);
+};
+MQEmitterRedisPrefix.prototype.emit = function(packet, done){
+	var t = this._pubSubPrefix+packet.topic;
+	var p = { ...packet, topic: t };
+	return MQEmitterRedis.prototype.emit.call(this, p, done);
 };
 
 module.exports.MQEmitterRedisPrefix = MQEmitterRedisPrefix;

--- a/mqemitter-redis.js
+++ b/mqemitter-redis.js
@@ -200,7 +200,7 @@ module.exports = MQEmitterRedis
 function MQEmitterRedisPrefix (pubSubPrefix, options) {
   MQEmitterRedis.call(this, options)
   this._pubSubPrefix = pubSubPrefix
-  this._sym_proxiedCallback = Symbol('proxiedCallback');
+  this._sym_proxiedCallback = Symbol('proxiedCallback')
 }
 inherits(MQEmitterRedisPrefix, MQEmitterRedis)
 MQEmitterRedisPrefix.prototype.on = function (topic, cb, done) {

--- a/mqemitter-redis.js
+++ b/mqemitter-redis.js
@@ -200,7 +200,7 @@ module.exports = MQEmitterRedis
 function MQEmitterRedisPrefix (pubSubPrefix, options) {
   MQEmitterRedis.call(this, options)
   this._pubSubPrefix = pubSubPrefix
-  this._sym_proxiedCallback = '_private_symbol_MQEmitterRedisPrefix_proxiedCallback' // Symbol('proxiedCallback');
+  this._sym_proxiedCallback = Symbol('proxiedCallback');
 }
 inherits(MQEmitterRedisPrefix, MQEmitterRedis)
 MQEmitterRedisPrefix.prototype.on = function (topic, cb, done) {

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ abstractTests({
 })
 
 abstractTests({
-  builder: function(opts) { return new redis.MQEmitterRedisPrefix('some_prefix/',opts); },
+  builder: function (opts) { return new redis.MQEmitterRedisPrefix('some_prefix/', opts) },
   test: test
 })
 

--- a/test.js
+++ b/test.js
@@ -9,6 +9,11 @@ abstractTests({
   test: test
 })
 
+abstractTests({
+  builder: function(opts) { return new redis.MQEmitterRedisPrefix('some_prefix/',opts); },
+  test: test
+})
+
 function noop () {}
 
 test('actual unsubscribe from Redis', function (t) {


### PR DESCRIPTION
allow running aedes on shared redis pub-sub by adding a topic prefix to prevent foreign pub-sub messages from interfering with aedes´s assert()ions

const { MQEmitterRedisPrefix } = require('mqemitter-redis');
const myprefix = 'mqemitter_prefix/';
mq = new MQEmitterRedisPrefix(myprefix, {
	port: this.mqttBrokerOptions.redisPort,
	host: this.mqttBrokerOptions.redisHost,
	db: 12
});