### PR TITLE
support passing a connection string to ioredis

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ mq.emit(msg, function () {
 })
 ```
 
+Connection String Example
+-------------------------
+
+```js
+var redis = require('mqemitter-redis')
+var mq = redis({
+  connectionString: 'redis://:authpassword@127.0.0.1:6380/4'
+})
+```
+
 ## API
 
 <a name="constructor"></a>

--- a/mqemitter-redis.js
+++ b/mqemitter-redis.js
@@ -18,8 +18,8 @@ function MQEmitterRedis (opts) {
 
   this._opts = opts
 
-  this.subConn = new Redis(opts)
-  this.pubConn = new Redis(opts)
+  this.subConn = new Redis(opts.connectionString || opts)
+  this.pubConn = new Redis(opts.connectionString || opts)
 
   this._pipeline = Pipeline(this.pubConn)
 

--- a/test.js
+++ b/test.js
@@ -87,3 +87,30 @@ test('topic pattern adapter', function (t) {
     t.end()
   })
 })
+
+test('ioredis connection string', function (t) {
+  const e = redis({
+    connectionString: 'redis://localhost:6379/0'
+  })
+
+  let subConnectEventReceived = false
+  let pubConnectEventReceived = false
+
+  e.state.on('pubConnect', function () {
+    pubConnectEventReceived = true
+    newConnectionEvent()
+  })
+
+  e.state.on('subConnect', function () {
+    subConnectEventReceived = true
+    newConnectionEvent()
+  })
+
+  function newConnectionEvent () {
+    if (subConnectEventReceived && pubConnectEventReceived) {
+      e.close(function () {
+        t.end()
+      })
+    }
+  }
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,6 +7,7 @@ export interface MQEmitterOptions {
   separator?: string;
   wildcardOne?: string;
   wildcardSome?: string;
+  connectionString?: string;
 }
 
 export type Message = Record<string, any> & { topic: string };

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -14,6 +14,7 @@ expectType<MQEmitterRedis>(
     separator: '/',
     wildcardOne: '+',
     wildcardSome: '#',
+    connectionString: 'redis://:authpassword@127.0.0.1:6380/4',
   })
 );
 


### PR DESCRIPTION
ioredis supports passing in a connection string in the constructor but the way this library is currently using ioredis, it's forcing use of an object. I'm proposing that we add a new `connectionString` property which can be used to pass into the ioredis constuctor. It seemed like the simplest way of adding support for the connection string.