### PR TITLE
chore: modernize dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
-        redis-tag: [5, 6]
-
+        node-version: [20.x, 22.x]
+        redis-tag: [7.2, 7.4]
     services:
       redis:
         image: redis:${{ matrix.redis-tag }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-  - "10"
-  - "12"
-  - "13"
-  - "14"
-  - "15"
-services:
-  - redis

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,1 @@
+module.exports = require('neostandard')(({ ts: true }))

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.2.0",
     "eslint": "^9.24.0",
+    "faucet": "^0.0.4",
     "neostandard": "^0.12.1",
     "tape": "^5.9.0",
     "tsd": "^0.31.2"
@@ -25,7 +26,7 @@
   "scripts": {
     "lint:fix": "eslint --fix",
     "lint": "eslint",
-    "unit": "tape test/*.js",
+    "unit": "tape test/*.js | faucet",
     "test:types": "tsd",
     "test": "npm run lint && npm run unit && tsd",
     "redis": "docker run -d --rm --name redis -p 6379:6379 redis:7"

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "mqemitter-redis.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "hyperid": "^3.2.0",
+    "hyperid": "^3.3.0",
     "inherits": "^2.0.4",
-    "ioredis": "^5.4.1",
-    "lru-cache": "^10.2.2",
+    "ioredis": "^5.6.0",
+    "lru-cache": "^11.1.0",
     "mqemitter": "^6.0.2",
     "msgpack-lite": "^0.1.26"
   },
@@ -16,8 +16,8 @@
     "@fastify/pre-commit": "^2.2.0",
     "eslint": "^9.24.0",
     "neostandard": "^0.12.1",
-    "tape": "^5.0.1",
-    "tsd": "^0.31.0"
+    "tape": "^5.9.0",
+    "tsd": "^0.31.2"
   },
   "scripts": {
     "lint:fix": "eslint --fix",

--- a/package.json
+++ b/package.json
@@ -13,16 +13,19 @@
     "msgpack-lite": "^0.1.26"
   },
   "devDependencies": {
-    "faucet": "^0.0.4",
-    "pre-commit": "^1.2.2",
-    "safe-buffer": "^5.2.1",
-    "standard": "^17.1.0",
+    "@fastify/pre-commit": "^2.2.0",
+    "eslint": "^9.24.0",
+    "neostandard": "^0.12.1",
     "tape": "^5.0.1",
     "tsd": "^0.31.0"
   },
   "scripts": {
+    "lint:fix": "eslint --fix",
+    "lint": "eslint",
+    "unit": "tape test/*.js",
     "test:types": "tsd",
-    "test": "standard && tape test/*.js | faucet && tsd"
+    "test": "npm run lint && npm run unit && tsd",
+    "redis": "docker run -d --rm --name redis -p 6379:6379 redis:7"
   },
   "pre-commit": "test",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Redis-based MQEmitter",
   "main": "mqemitter-redis.js",
   "types": "types/index.d.ts",
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
     "hyperid": "^3.3.0",
     "inherits": "^2.0.4",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
-import type { RedisOptions } from 'ioredis';
-import type { MQEmitter } from 'mqemitter';
+import type { RedisOptions } from 'ioredis'
+import type { MQEmitter } from 'mqemitter'
 
 export interface MQEmitterOptions {
   concurrency?: number;
@@ -15,7 +15,7 @@ export interface LRUCacheOptions {
   maxLRUCache?: number;// Maximum number of items in the LRU cache
 }
 
-export type Message = Record<string, any> & { topic: string };
+export type Message = Record<string, any> & { topic: string }
 
 export interface MQEmitterRedis extends MQEmitter {
   new (options?: MQEmitterOptions & RedisOptions & LRUCacheOptions): MQEmitterRedis;
@@ -35,8 +35,8 @@ export interface MQEmitterRedis extends MQEmitter {
   close(callback: () => void): void;
 }
 
-declare function MQEmitterRedis(
+declare function MQEmitterRedis (
   options?: MQEmitterOptions & RedisOptions & LRUCacheOptions
-): MQEmitterRedis;
+): MQEmitterRedis
 
-export default MQEmitterRedis;
+export default MQEmitterRedis

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,11 +1,11 @@
-import { expectError, expectType } from 'tsd';
-import mqEmitterRedis, { Message, MQEmitterRedis } from '.';
+import { expectError, expectType } from 'tsd'
+import mqEmitterRedis, { Message, MQEmitterRedis } from '.'
 
-expectType<MQEmitterRedis>(mqEmitterRedis());
+expectType<MQEmitterRedis>(mqEmitterRedis())
 
 expectType<MQEmitterRedis>(
   mqEmitterRedis({ concurrency: 200, matchEmptyLevels: true })
-);
+)
 
 expectType<MQEmitterRedis>(
   mqEmitterRedis({
@@ -16,7 +16,7 @@ expectType<MQEmitterRedis>(
     wildcardSome: '#',
     connectionString: 'redis://:authpassword@127.0.0.1:6380/4',
   })
-);
+)
 
 expectType<MQEmitterRedis>(
   mqEmitterRedis({
@@ -24,26 +24,27 @@ expectType<MQEmitterRedis>(
     matchEmptyLevels: true,
     host: 'localhost',
     port: 6379,
+    // eslint-disable-next-line n/handle-callback-err
     reconnectOnError: (error: Error) => true,
     retryStrategy: (times: number) => times * 1.5,
   })
-);
+)
 
 expectType<MQEmitterRedis>(
   mqEmitterRedis({
     maxLRUCache: 100,
     ttlLRUCache: 10000,
   })
-);
+)
 
-function listener(message: Message, done: () => void) {}
+function listener (message: Message, done: () => void) {}
 
-expectType<MQEmitterRedis>(mqEmitterRedis().on('topic', listener));
+expectType<MQEmitterRedis>(mqEmitterRedis().on('topic', listener))
 
-expectType<void>(mqEmitterRedis().removeListener('topic', listener));
+expectType<void>(mqEmitterRedis().removeListener('topic', listener))
 
-expectError(mqEmitterRedis().emit(null));
+expectError(mqEmitterRedis().emit(null))
 
-expectType<void>(mqEmitterRedis().emit({ topic: 'test', prop1: 'prop1' }));
+expectType<void>(mqEmitterRedis().emit({ topic: 'test', prop1: 'prop1' }))
 
-expectType<void>(mqEmitterRedis().close(() => null));
+expectType<void>(mqEmitterRedis().close(() => null))


### PR DESCRIPTION
This PR:

- updates package.json to:
  - update all dependencies to their latest versions
  - remove `safe-buffer` as it was not used
  - replace `standard`  by `neostandard`
  - replace `pre-commit` by `@fastify/pre-commit` as `pre-commit` had its last update 8 years ago
  - set the engine version to >=20 as `lru-cache@11` does not support node 18 anymore and 18 ends LTS end of this month
  - add conveniece scripts like `lint:fix` and `redis`
- fixes the linting errors found in `types/index.test-d.ts` and `types/index.d.ts`
- updates CI to use:
   - node 20 and 22 , now that the engine version is set to >=20
   - redis 7.2 and 7.4 as 7.0 is already end of life (see https://endoflife.date/redis)
 - removes `.travis.yml` as its no longer used and the highest version of node that it contained was 15
   