### PR TITLE
chore: migrate to node:test

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,23 +10,21 @@
   "dependencies": {
     "hyperid": "^3.3.0",
     "inherits": "^2.0.4",
-    "ioredis": "^5.6.0",
+    "ioredis": "^5.6.1",
     "lru-cache": "^11.1.0",
-    "mqemitter": "^6.0.2",
+    "mqemitter": "^7.0.0",
     "msgpack-lite": "^0.1.26"
   },
   "devDependencies": {
     "@fastify/pre-commit": "^2.2.0",
     "eslint": "^9.24.0",
-    "faucet": "^0.0.4",
     "neostandard": "^0.12.1",
-    "tape": "^5.9.0",
-    "tsd": "^0.31.2"
+    "tsd": "^0.32.0"
   },
   "scripts": {
     "lint:fix": "eslint --fix",
     "lint": "eslint",
-    "unit": "tape test/*.js | faucet",
+    "unit": "node --test test/*.js",
     "test:types": "tsd",
     "test": "npm run lint && npm run unit && tsd",
     "redis": "docker run -d --rm --name redis -p 6379:6379 redis:7"

--- a/test/base.js
+++ b/test/base.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const redis = require('../')
-const test = require('tape').test
+const { test } = require('node:test')
 const abstractTests = require('mqemitter/abstractTest.js')
 
 abstractTests({

--- a/test/own.js
+++ b/test/own.js
@@ -2,153 +2,159 @@
 
 const redis = require('../')
 const Redis = require('ioredis')
-const test = require('tape').test
+const { test } = require('node:test')
 
 function noop () {}
 
-test('actual unsubscribe from Redis', function (t) {
-  const e = redis()
+test('actual unsubscribe from Redis', async function (t) {
+  t.plan(1)
+  await new Promise(resolve => {
+    const e = redis()
 
-  e.subConn.on('message', function (topic, message) {
-    t.fail('the message should not be emitted')
-  })
+    e.subConn.on('message', function (topic, message) {
+      t.assert.fail('the message should not be emitted')
+    })
 
-  e.on('hello', noop)
-  e.removeListener('hello', noop)
-  e.emit({ topic: 'hello' }, function (err) {
-    t.notOk(err)
-    e.close(function () {
-      t.end()
+    e.on('hello', noop)
+    e.removeListener('hello', noop)
+    e.emit({ topic: 'hello' }, function (err) {
+      t.assert.ok(!err)
+      e.close(resolve)
     })
   })
 })
 
-test('ioredis connect event', function (t) {
-  const e = redis()
+test('ioredis connect event', async function (t) {
+  t.plan(2)
 
-  let subConnectEventReceived = false
-  let pubConnectEventReceived = false
+  await new Promise(resolve => {
+    const e = redis()
 
-  e.state.on('pubConnect', function () {
-    pubConnectEventReceived = true
-    newConnectionEvent()
-  })
+    let subConnectEventReceived = false
+    let pubConnectEventReceived = false
 
-  e.state.on('subConnect', function () {
-    subConnectEventReceived = true
-    newConnectionEvent()
-  })
+    e.state.on('pubConnect', function () {
+      pubConnectEventReceived = true
+      newConnectionEvent()
+    })
 
-  function newConnectionEvent () {
-    if (subConnectEventReceived && pubConnectEventReceived) {
-      e.close(function () {
-        t.end()
-      })
+    e.state.on('subConnect', function () {
+      subConnectEventReceived = true
+      newConnectionEvent()
+    })
+
+    function newConnectionEvent () {
+      t.assert.ok(true, 'connect event received')
+      if (subConnectEventReceived && pubConnectEventReceived) {
+        e.close(resolve)
+      }
     }
-  }
+  })
 })
 
-test('ioredis error event', function (t) {
-  const e = redis({ host: '127' })
-
+test('ioredis error event', async function (t) {
   t.plan(1)
 
-  e.state.once('error', function (err) {
-    t.deepEqual(err.message.substr(0, 7), 'connect')
-    e.close(function () {
-      t.end()
+  await new Promise(resolve => {
+    const e = redis({ host: '127' })
+    e.state.once('error', function (err) {
+      t.assert.deepEqual(err.message.substr(0, 7), 'connect')
+      e.close(resolve)
     })
   })
 })
 
-test('topic pattern adapter', function (t) {
-  const e = redis()
-
-  const mqttTopic = 'rooms/+/devices/+/status'
-  const expectedRedisPattern = 'rooms/*/devices/*/status'
-
-  const subTopic = e._subTopic(mqttTopic)
-
+test('topic pattern adapter', async function (t) {
   t.plan(1)
 
-  t.deepEqual(subTopic, expectedRedisPattern)
+  await new Promise(resolve => {
+    const e = redis()
 
-  e.close(function () {
-    t.end()
+    const mqttTopic = 'rooms/+/devices/+/status'
+    const expectedRedisPattern = 'rooms/*/devices/*/status'
+
+    const subTopic = e._subTopic(mqttTopic)
+    t.assert.deepEqual(subTopic, expectedRedisPattern)
+    e.close(resolve)
   })
 })
 
-test('ioredis connection string', function (t) {
-  const e = redis({
-    connectionString: 'redis://localhost:6379/0'
-  })
+test('ioredis connection string', async function (t) {
+  t.plan(2)
 
-  let subConnectEventReceived = false
-  let pubConnectEventReceived = false
+  await new Promise(resolve => {
+    const e = redis({
+      connectionString: 'redis://localhost:6379/0'
+    })
 
-  e.state.on('pubConnect', function () {
-    pubConnectEventReceived = true
-    newConnectionEvent()
-  })
+    let subConnectEventReceived = false
+    let pubConnectEventReceived = false
 
-  e.state.on('subConnect', function () {
-    subConnectEventReceived = true
-    newConnectionEvent()
-  })
+    e.state.on('pubConnect', function () {
+      pubConnectEventReceived = true
+      newConnectionEvent()
+    })
 
-  function newConnectionEvent () {
-    if (subConnectEventReceived && pubConnectEventReceived) {
-      e.close(function () {
-        t.end()
-      })
+    e.state.on('subConnect', function () {
+      subConnectEventReceived = true
+      newConnectionEvent()
+    })
+
+    function newConnectionEvent () {
+      t.assert.ok(true, 'connect event received')
+      if (subConnectEventReceived && pubConnectEventReceived) {
+        e.close(resolve)
+      }
     }
-  }
+  })
 })
 
-test('external redis pubConn and subConn', function (t) {
+test('external redis pubConn and subConn', async function (t) {
   t.plan(4)
 
-  const externalRedisSubConn = new Redis()
-  externalRedisSubConn.on('error', e => {
-    t.notOk(e)
-  })
-  externalRedisSubConn.on('connect', () => {
-    t.pass('redis subConn connected')
-  })
+  await new Promise(resolve => {
+    const externalRedisSubConn = new Redis()
+    externalRedisSubConn.on('error', e => {
+      t.assert.ok(!e)
+    })
+    externalRedisSubConn.on('connect', () => {
+      t.assert.ok(true, 'redis subConn connected')
+    })
 
-  const externalRedisPubConn = new Redis()
-  externalRedisPubConn.on('error', e => {
-    t.notOk(e)
-  })
-  externalRedisPubConn.on('connect', () => {
-    t.pass('redis pubConn connected')
-  })
+    const externalRedisPubConn = new Redis()
+    externalRedisPubConn.on('error', e => {
+      t.assert.ok(!e)
+    })
+    externalRedisPubConn.on('connect', () => {
+      t.assert.ok(true, 'redis pubConn connected')
+    })
 
-  const e = redis({
-    subConn: externalRedisSubConn,
-    pubConn: externalRedisPubConn
-  })
+    const e = redis({
+      subConn: externalRedisSubConn,
+      pubConn: externalRedisPubConn
+    })
 
-  let subConnectEventReceived = false
-  let pubConnectEventReceived = false
+    let subConnectEventReceived = false
+    let pubConnectEventReceived = false
 
-  e.state.on('pubConnect', function () {
-    pubConnectEventReceived = true
-    newConnectionEvent()
-  })
+    e.state.on('pubConnect', function () {
+      pubConnectEventReceived = true
+      newConnectionEvent()
+    })
 
-  e.state.on('subConnect', function () {
-    subConnectEventReceived = true
-    newConnectionEvent()
-  })
+    e.state.on('subConnect', function () {
+      subConnectEventReceived = true
+      newConnectionEvent()
+    })
 
-  function newConnectionEvent () {
-    if (subConnectEventReceived && pubConnectEventReceived) {
-      e.close(function () {
-        t.equal(e.subConn, externalRedisSubConn, 'uses external redis subConn')
-        t.equal(e.pubConn, externalRedisPubConn, 'uses external redis pubConn')
-        t.end()
-      })
+    function newConnectionEvent () {
+      if (subConnectEventReceived && pubConnectEventReceived) {
+        e.close(function () {
+          t.assert.equal(e.subConn, externalRedisSubConn, 'uses external redis subConn')
+          t.assert.equal(e.pubConn, externalRedisPubConn, 'uses external redis pubConn')
+          resolve()
+        })
+      }
     }
-  }
+  })
 })

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const redis = require('../')
-const test = require('tape').test
+const { test } = require('node:test')
 const abstractTests = require('mqemitter/abstractTest.js')
 
 abstractTests({


### PR DESCRIPTION
This PR:

- migrates tests to use node:test by using mqemitter@7
- updates ioredis and tsd to their latest minor/patch versions as well

Kind regards,
Hans